### PR TITLE
ballle98/AqualinkD#6: filter pump status is going on and off when spa

### DIFF
--- a/aqualinkd.c
+++ b/aqualinkd.c
@@ -416,36 +416,39 @@ void pass_pda_equiptment_status_item(char* msg)
   }
   else
   {
-	char labelBuff[AQ_MSGLEN+1];
-	strncpy(labelBuff, msg, AQ_MSGLEN+1);
-	msg = stripwhitespace(labelBuff);
+      char labelBuff[AQ_MSGLEN + 1];
+      strncpy (labelBuff, msg, AQ_MSGLEN + 1);
+      msg = stripwhitespace (labelBuff);
 
-    // These are listed as "  FILTER PUMP   "
+      // These are listed as "  FILTER PUMP   "
 
-	if (strcasecmp(msg, "POOL HEAT ENA") == 0)
-	{
-		_aqualink_data.aqbuttons[POOL_HEAT_INDEX].led->state = ENABLE;
-	}
-	else if (strcasecmp(msg, "SPA HEAT ENA") == 0)
-	{
-		_aqualink_data.aqbuttons[SPA_HEAT_INDEX].led->state = ENABLE;
-	}
-	else
-	{
-		for (i = 0; i < TOTAL_BUTTONS; i++)
-		{
-		  if (strcasecmp(msg, _aqualink_data.aqbuttons[i].pda_label) == 0)
-		  {
-			logMessage(LOG_DEBUG,"*** Found Status for %s = '%.*s'\n", _aqualink_data.aqbuttons[i].pda_label, AQ_MSGLEN, msg);
-			// It's on (or delayed) if it's listed here.
-        	if (_aqualink_data.aqbuttons[i].led->state != FLASH) {
-        		_aqualink_data.aqbuttons[i].led->state = ON;
-        	}
-			break;
-		  }
-		}
-	}
-  }
+      if (strcasecmp (msg, "POOL HEAT ENA") == 0)
+        {
+          _aqualink_data.aqbuttons[POOL_HEAT_INDEX].led->state = ENABLE;
+        }
+      else if (strcasecmp (msg, "SPA HEAT ENA") == 0)
+        {
+          _aqualink_data.aqbuttons[SPA_HEAT_INDEX].led->state = ENABLE;
+        }
+      else
+        {
+          for (i = 0; i < TOTAL_BUTTONS; i++)
+            {
+              if (strcasecmp (msg, _aqualink_data.aqbuttons[i].pda_label) == 0)
+                {
+                  logMessage (LOG_DEBUG, "*** Found Status for %s = '%.*s'\n",
+                              _aqualink_data.aqbuttons[i].pda_label, AQ_MSGLEN,
+                              msg);
+                  // It's on (or delayed) if it's listed here.
+                  if (_aqualink_data.aqbuttons[i].led->state != FLASH)
+                    {
+                      _aqualink_data.aqbuttons[i].led->state = ON;
+                    }
+                  break;
+                }
+            }
+        }
+    }
 }
 
 bool process_pda_packet(unsigned char* packet, int length)
@@ -482,12 +485,12 @@ bool process_pda_packet(unsigned char* packet, int length)
       // or pending so unless flash turn everything off, and just turn on items that are listed.
       // This is the only way to update a device that's been turned off by a real PDA / keypad.
       if (pda_m_type() == PM_EQUIPTMENT_STATUS) {
-        //printf("*** SET ALL OFF ****\n");
-        for (i = 0; i < TOTAL_BUTTONS; i++) {
-        	if (_aqualink_data.aqbuttons[i].led->state != FLASH) {
-        		_aqualink_data.aqbuttons[i].led->state = OFF;
-        	}
-        }
+          //printf("*** SET ALL OFF ****\n");
+          for (i = 0; i < TOTAL_BUTTONS; i++) {
+              if (_aqualink_data.aqbuttons[i].led->state != FLASH) {
+                  _aqualink_data.aqbuttons[i].led->state = OFF;
+              }
+          }
         for (i = 1; i < PDA_LINES; i++) {
           pass_pda_equiptment_status_item(pda_m_line(i));
         }
@@ -556,17 +559,25 @@ bool process_pda_packet(unsigned char* packet, int length)
         }
       } else if (pda_m_type() == PM_MAIN || pda_m_type() == PM_BUILDING_MAIN) {
         if (stristr(msg, "POOL MODE") != NULL) {
-        	// If pool mode is on the filter pump is on but if it is off the filter pump might be on if spa mode is on.
-        	if (msg[AQ_MSGLEN-1] == 'N') {
-        		_aqualink_data.aqbuttons[PUMP_INDEX].led->state = ON;
-        	} else if (msg[AQ_MSGLEN-1] == '*') {
-        		_aqualink_data.aqbuttons[PUMP_INDEX].led->state = FLASH;
-        	}
+            // If pool mode is on the filter pump is on but if it is off the filter pump might be on if spa mode is on.
+            if (msg[AQ_MSGLEN-1] == 'N') {
+                _aqualink_data.aqbuttons[PUMP_INDEX].led->state = ON;
+            } else if (msg[AQ_MSGLEN-1] == '*') {
+                _aqualink_data.aqbuttons[PUMP_INDEX].led->state = FLASH;
+            }
         }else if (stristr(msg, "POOL HEATER") != NULL) {
           set_pda_led(_aqualink_data.aqbuttons[POOL_HEAT_INDEX].led, msg[AQ_MSGLEN-1]);
         }else if (stristr(msg, "SPA MODE") != NULL) {
-        	// when SPA mode is on the filter may be on or pending
-          set_pda_led(_aqualink_data.aqbuttons[SPA_INDEX].led, msg[AQ_MSGLEN-1]);
+            // when SPA mode is on the filter may be on or pending
+            if (msg[AQ_MSGLEN-1] == 'N') {
+                _aqualink_data.aqbuttons[PUMP_INDEX].led->state = ON;
+                _aqualink_data.aqbuttons[SPA_INDEX].led->state = ON;
+            } else if (msg[AQ_MSGLEN-1] == '*') {
+                _aqualink_data.aqbuttons[PUMP_INDEX].led->state = FLASH;
+                _aqualink_data.aqbuttons[SPA_INDEX].led->state = ON;
+            } else {
+                _aqualink_data.aqbuttons[SPA_INDEX].led->state = OFF;
+            }
         }else if (stristr(msg, "SPA HEATER") != NULL) {
           set_pda_led(_aqualink_data.aqbuttons[SPA_HEAT_INDEX].led, msg[AQ_MSGLEN-1]);
         }


### PR DESCRIPTION
mode is on

Additional fix to clean up SPA status when read from main PDA menu.  The
flashing is for filter pump and not for SPA

Note: there is a big block of white space changes at the beginning because my editor did not have tabs disabled when I did previous fix.  The real change is at the very end.