### PR TITLE
using rm -f $(wildcard *.o) instead of *.o so make clean on windows will

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(PLAY): $(PL_OBJS) $(PL_EXOBJ)
 	$(CC) $(CFLAGS) $(INCLUDES) -c $<  -o $@
 
 clean:
-	$(RM) *.o *~ $(MAIN) $(MAIN_U) $(PLAY) $(PL_EXOBJ)
+	$(RM) $(wildcard *.o) $(wildcard *~) $(MAIN) $(MAIN_U) $(PLAY) $(PL_EXOBJ)
 
 depend: $(SRCS)
 	makedepend $(INCLUDES) $^


### PR DESCRIPTION
This allows make clean to work in a non-Linux environment like cross compiling from windows in Eclipse.

see https://stackoverflow.com/questions/11056077/rm-f-and-makefile