### PR TITLE
ballle98/AqualinkD#31: mutex init and cond init called multiple times

### DIFF
--- a/aq_programmer.c
+++ b/aq_programmer.c
@@ -1226,7 +1226,6 @@ bool waitForEitherMessage(struct aqualinkdata *aq_data, char* message1, char* me
 {
   //logMessage(LOG_DEBUG, "waitForMessage %s %d %d\n",message,numMessageReceived,cmd);
   int i=0;
-  pthread_mutex_init(&aq_data->active_thread.thread_mutex, NULL);
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
   char* msgS1;
   char* msgS2;
@@ -1272,7 +1271,6 @@ bool waitForEitherMessage(struct aqualinkdata *aq_data, char* message1, char* me
     }
     
     //logMessage(LOG_DEBUG, "Programming mode: looking for '%s' received message1 '%s'\n",message1,aq_data->last_message);
-    pthread_cond_init(&aq_data->active_thread.thread_cond, NULL);
     pthread_cond_wait(&aq_data->active_thread.thread_cond, &aq_data->active_thread.thread_mutex);
     //logMessage(LOG_DEBUG, "Programming mode: loop %d of %d looking for '%s' received message1 '%s'\n",i,numMessageReceived,message1,aq_data->last_message);
   }
@@ -1295,7 +1293,6 @@ bool waitForMessage(struct aqualinkdata *aq_data, char* message, int numMessageR
 {
   logMessage(LOG_DEBUG, "waitForMessage %s %d\n",message,numMessageReceived);
   int i=0;
-  pthread_mutex_init(&aq_data->active_thread.thread_mutex, NULL);
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
   char* msgS;
   char* ptr = NULL;
@@ -1326,7 +1323,6 @@ bool waitForMessage(struct aqualinkdata *aq_data, char* message, int numMessageR
     }
     
     //logMessage(LOG_DEBUG, "Programming mode: looking for '%s' received message '%s'\n",message,aq_data->last_message);
-    pthread_cond_init(&aq_data->active_thread.thread_cond, NULL);
     pthread_cond_wait(&aq_data->active_thread.thread_cond, &aq_data->active_thread.thread_mutex);
     //logMessage(LOG_DEBUG, "Programming mode: loop %d of %d looking for '%s' received message '%s'\n",i,numMessageReceived,message,aq_data->last_message);
   }
@@ -1427,7 +1423,6 @@ bool waitForButtonState(struct aqualinkdata *aq_data, aqkey* button, aqledstate 
 {
   //logMessage(LOG_DEBUG, "waitForMessage %s %d %d\n",message,numMessageReceived,cmd);
   int i=0;
-  pthread_mutex_init(&aq_data->active_thread.thread_mutex, NULL);
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
 
   while( ++i <= numMessageReceived)
@@ -1440,7 +1435,6 @@ bool waitForButtonState(struct aqualinkdata *aq_data, aqkey* button, aqledstate 
     }
 
     //logMessage(LOG_DEBUG, "Programming mode: looking for '%s' received message '%s'\n",message,aq_data->last_message);
-    pthread_cond_init(&aq_data->active_thread.thread_cond, NULL);
     pthread_cond_wait(&aq_data->active_thread.thread_cond, &aq_data->active_thread.thread_mutex);
     //logMessage(LOG_DEBUG, "Programming mode: loop %d of %d looking for '%s' received message '%s'\n",i,numMessageReceived,message,aq_data->last_message);
   }

--- a/aqualinkd.c
+++ b/aqualinkd.c
@@ -1024,6 +1024,9 @@ void main_loop()
   _aqualink_data.battery = OK;
   _aqualink_data.open_websockets = 0;
 
+  pthread_mutex_init(&_aqualink_data.active_thread.thread_mutex, NULL);
+  pthread_cond_init(&_aqualink_data.active_thread.thread_cond, NULL);
+
   for (i=0; i < MAX_PUMPS; i++) {
     _aqualink_data.pumps[i].rpm = TEMP_UNKNOWN;
     _aqualink_data.pumps[i].gph = TEMP_UNKNOWN;

--- a/pda_aq_programmer.c
+++ b/pda_aq_programmer.c
@@ -521,7 +521,6 @@ bool waitForPDAMessageHighlight(struct aqualinkdata *aq_data, int highlighIndex,
   if(pda_m_hlightindex() == highlighIndex) return true;
 
   int i=0;
-  pthread_mutex_init(&aq_data->active_thread.thread_mutex, NULL);
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
 
   while( ++i <= numMessageReceived)
@@ -530,7 +529,6 @@ bool waitForPDAMessageHighlight(struct aqualinkdata *aq_data, int highlighIndex,
 
     if (aq_data->last_packet_type == CMD_PDA_HIGHLIGHT && pda_m_hlightindex() == highlighIndex) break;
 
-    pthread_cond_init(&aq_data->active_thread.thread_cond, NULL);
     pthread_cond_wait(&aq_data->active_thread.thread_cond, &aq_data->active_thread.thread_mutex);
   }
 
@@ -552,7 +550,6 @@ bool waitForPDAMessageType(struct aqualinkdata *aq_data, unsigned char mtype, in
   logMessage(LOG_DEBUG, "waitForPDAMessageType  0x%02hhx\n",mtype);
 
   int i=0;
-  pthread_mutex_init(&aq_data->active_thread.thread_mutex, NULL);
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
 
   while( ++i <= numMessageReceived)
@@ -561,7 +558,6 @@ bool waitForPDAMessageType(struct aqualinkdata *aq_data, unsigned char mtype, in
 
     if (aq_data->last_packet_type == mtype) break;
 
-    pthread_cond_init(&aq_data->active_thread.thread_cond, NULL);
     pthread_cond_wait(&aq_data->active_thread.thread_cond, &aq_data->active_thread.thread_mutex);
   }
 
@@ -584,7 +580,6 @@ bool waitForPDAMessageTypesOrMenu(struct aqualinkdata *aq_data, unsigned char mt
 
   int i=0;
   bool gotmenu = false;
-  pthread_mutex_init(&aq_data->active_thread.thread_mutex, NULL);
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
 
   while( ++i <= numMessageReceived)
@@ -600,7 +595,6 @@ bool waitForPDAMessageTypesOrMenu(struct aqualinkdata *aq_data, unsigned char mt
 
     if (aq_data->last_packet_type == mtype1 || aq_data->last_packet_type == mtype2) break;
 
-    pthread_cond_init(&aq_data->active_thread.thread_cond, NULL);
     pthread_cond_wait(&aq_data->active_thread.thread_cond, &aq_data->active_thread.thread_mutex);
   }
 


### PR DESCRIPTION
Fix #81 

pthread_mutex_init() and  pthread_cond_init() are called multiple times on the same mutex or cond.  The proper behavior is to call it one time during initialization otherwise you have to insure that no threads are using it and destroy it before initializing it again.

see https://linux.die.net/man/3/pthread_mutex_init

... "Attempting to initialize an already initialized mutex results in undefined behavior." 
