### PR TITLE
Adding required header file as per open() docs

### DIFF
--- a/aq_programmer.c
+++ b/aq_programmer.c
@@ -1232,8 +1232,8 @@ bool waitForEitherMessage(struct aqualinkdata *aq_data, char* message1, char* me
   //logMessage(LOG_DEBUG, "waitForMessage %s %d %d\n",message,numMessageReceived,cmd);
   int i=0;
   pthread_mutex_lock(&aq_data->active_thread.thread_mutex);
-  char* msgS1;
-  char* msgS2;
+  char* msgS1 = "";
+  char* msgS2 = "";
   char* ptr = NULL;
   
   

--- a/utils.c
+++ b/utils.c
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <ctype.h>
+#include <fcntl.h>
 
 #ifdef AD_DEBUG
 #include <sys/time.h>


### PR DESCRIPTION
In compiling on a platform (onion omega) I ran into an undeclared compiler error for O_CREAT, O_WRONLY, etc.
The docs state that these are defined in <fcntl.h> per:
https://pubs.opengroup.org/onlinepubs/007908799/xsh/open.html

Adding this include allows for at least compilation out of the box for MIPS platform.  Not sure about runtime yet.