### PR TITLE
auto-set temperature units for pda systems

### DIFF
--- a/aqualink.h
+++ b/aqualink.h
@@ -21,6 +21,7 @@
 #define MAX_ZERO_READ_BEFORE_RECONNECT 10000 // 2k normally
 
 void intHandler(int dummy);
+void setUnits(const char *msg);
 
 // There are cases where SWG will read 80% in allbutton and 0% in onetouch/aqualinktouch, this will compile that in or our
 //#define READ_SWG_FROM_EXTENDED_ID

--- a/aqualinkd.c
+++ b/aqualinkd.c
@@ -174,18 +174,26 @@ bool checkAqualinkTime()
 }
 
 
-void setUnits(char *msg)
+void setUnits(const char *msg)
 {
   char buf[AQ_MSGLEN*3];
 
   rsm_strncpy(buf, (unsigned char *)msg, AQ_MSGLEN*3, AQ_MSGLONGLEN);
 
-  //ascii(buf, msg);
-  LOG(AQUA_LOG,LOG_DEBUG, "Getting temp units from message '%s', looking at '%c'\n", buf, buf[strlen(buf) - 1]);
+  // Back up until we find a non space character.
+  int l = strlen(buf);
+  while (l > 0) {
+    if (!isspace(buf[l-1]))
+      break;
+    l--;
+  }
 
-  if (msg[strlen(msg) - 1] == 'F')
+  //ascii(buf, msg);
+  LOG(AQUA_LOG,LOG_DEBUG, "Getting temp units from message '%s', looking at '%c'\n", buf, buf[l - 1]);
+
+  if (msg[l - 1] == 'F')
     _aqualink_data.temp_units = FAHRENHEIT;
-  else if (msg[strlen(msg) - 1] == 'C')
+  else if (msg[l - 1] == 'C')
     _aqualink_data.temp_units = CELSIUS;
   else
     _aqualink_data.temp_units = UNKNOWN;

--- a/pda.c
+++ b/pda.c
@@ -240,7 +240,6 @@ void process_pda_packet_msg_long_temp(const char *msg)
   //           'AIR             '
   //           ' 86`            '
   //           'AIR        WATER'  // In case of single device.
-  _aqualink_data->temp_units = FAHRENHEIT; // Force FAHRENHEIT
   if (stristr(pda_m_line(1), "AIR") != NULL)
     _aqualink_data->air_temp = atoi(msg);
 
@@ -372,29 +371,39 @@ void setSingleDeviceMode()
 
 void process_pda_packet_msg_long_set_temp(const char *msg)
 {
+  //   message 'TEMP1       26`C   '
+  //           'TEMP2       15`C   '
   LOG(PDA_LOG,LOG_DEBUG, "process_pda_packet_msg_long_set_temp\n");
 
   if (stristr(msg, "POOL HEAT") != NULL)
   {
     _aqualink_data->pool_htr_set_point = atoi(msg + 10);
     LOG(PDA_LOG,LOG_DEBUG, "pool_htr_set_point = %d\n", _aqualink_data->pool_htr_set_point);
+    if (_aqualink_data->temp_units == UNKNOWN)
+      setUnits(msg);
   }
   else if (stristr(msg, "SPA HEAT") != NULL)
   {
     _aqualink_data->spa_htr_set_point = atoi(msg + 10);
     LOG(PDA_LOG,LOG_DEBUG, "spa_htr_set_point = %d\n", _aqualink_data->spa_htr_set_point);
+    if (_aqualink_data->temp_units == UNKNOWN)
+      setUnits(msg);
   }
   else if (stristr(msg, "TEMP1") != NULL)
   {
     setSingleDeviceMode();
     _aqualink_data->pool_htr_set_point = atoi(msg + 10);
     LOG(PDA_LOG,LOG_DEBUG, "pool_htr_set_point = %d\n", _aqualink_data->pool_htr_set_point);
+    if (_aqualink_data->temp_units == UNKNOWN)
+      setUnits(msg);
   }
   else if (stristr(msg, "TEMP2") != NULL)
   {
     setSingleDeviceMode();
     _aqualink_data->spa_htr_set_point = atoi(msg + 10);
     LOG(PDA_LOG,LOG_DEBUG, "spa_htr_set_point = %d\n", _aqualink_data->spa_htr_set_point);
+    if (_aqualink_data->temp_units == UNKNOWN)
+      setUnits(msg);
   }
 
  
@@ -428,10 +437,13 @@ void process_pda_packet_msg_long_pool_heat(const char *msg)
 
 void process_pda_packet_msg_long_freeze_protect(const char *msg)
 {
+  //   message 'TEMP         3`C   '
   if (strncasecmp(msg, "TEMP      ", 10) == 0)
   {
     _aqualink_data->frz_protect_set_point = atoi(msg + 10);
     LOG(PDA_LOG,LOG_DEBUG, "frz_protect_set_point = %d\n", _aqualink_data->frz_protect_set_point);
+    if (_aqualink_data->temp_units == UNKNOWN)
+      setUnits(msg);
   }
 }
 


### PR DESCRIPTION
This is intended to address issue:
[PDA temperatures are hardcoded to be in Fahrenheit](https://github.com/sfeakes/AqualinkD/issues/123)

by automatically setting the temperature units for pda systems.  It reuses the existing setUnits() function
and modifies it to walk back from the end of the line until it finds a character that isn't a space.  Should the
last character already be a non space character there is no change in behaviour.  The signature changed 
from `setUnits(char *msg)` to `setUnits(const char *msg)` to accommodate that in the pda code `msg` 
is declared as `const char *msg`, this has no effect on the callers presenting a `char *msg` to `setUnits()`.

Robert