### PR TITLE
Corrected temp resets in dual mode.

### DIFF
--- a/aqualinkd.c
+++ b/aqualinkd.c
@@ -750,7 +750,10 @@ bool process_packet(unsigned char *packet, int length)
     if (_aqualink_data.aqbuttons[PUMP_INDEX].led->state == OFF)
     {
       _aqualink_data.pool_temp = TEMP_UNKNOWN;
-      _aqualink_data.spa_temp = TEMP_UNKNOWN;
+      if(isSINGLE_DEV_PANEL == true)
+      {
+        _aqualink_data.spa_temp = TEMP_UNKNOWN;
+      }
       //_aqualink_data.spa_temp = _aqconfig_.report_zero_spa_temp?-18:TEMP_UNKNOWN;
     }
     else if (_aqualink_data.aqbuttons[SPA_INDEX].led->state == OFF && isSINGLE_DEV_PANEL != true)
@@ -758,7 +761,7 @@ bool process_packet(unsigned char *packet, int length)
       //_aqualink_data.spa_temp = _aqconfig_.report_zero_spa_temp?-18:TEMP_UNKNOWN;
       _aqualink_data.spa_temp = TEMP_UNKNOWN;
     }
-    else if (_aqualink_data.aqbuttons[SPA_INDEX].led->state == ON && isSINGLE_DEV_PANEL != true)
+    else if (_aqualink_data.aqbuttons[SPA_INDEX].led->state == ON && isSINGLE_DEV_PANEL == true)
     {
       _aqualink_data.pool_temp = TEMP_UNKNOWN;
     }


### PR DESCRIPTION
With a dual mode device (e.g my RS-2/6 Dual), the Pool temp was being set to TEMP_UNKNOWN on a status message when the spa pump was on.  This seems to be from a typo where you meant to say " isSINGLE_DEV_PANEL == true" but did != instead.
Similarly, but not exactly, the Spa temp was being set to TEMP_UNKNOWN on any status message when the Pool pump was off because there was no check to make sure " isSINGLE_DEV_PANEL == true"  before setting it to unknown.
I tested these changes on my Dual device and now it works as intended--Spa temp only set to unknown when Spa pump is off, and Pool temp only set to unknown when Pool pump is off.  Going through the code logically it seems it will work as intended for single device panels as well.