### PR TITLE
Update net_services.c

### DIFF
--- a/net_services.c
+++ b/net_services.c
@@ -1076,7 +1076,7 @@ void action_web_request(struct mg_connection *nc, struct http_message *http_msg)
     }
   //} else if (strstr(http_msg->method.p, "PUT")) {
   } else {
-    char buf[50];
+    char buf[100];
     float value = 0;
     DEBUG_TIMER_START(&tid);
 


### PR DESCRIPTION
buf was overflowing in sprintf on line 1163 when passed /api/dynamicconfig (the whole string was 54 characters).