### PR TITLE
Update net_services.c

### DIFF
--- a/net_services.c
+++ b/net_services.c
@@ -1160,7 +1160,7 @@ void action_web_request(struct mg_connection *nc, struct http_message *http_msg)
       mg_send_head(nc, 200, strlen(GET_RTN_UNKNOWN), CONTENT_TEXT);
       mg_send(nc, GET_RTN_UNKNOWN, strlen(GET_RTN_UNKNOWN));
     }
-    sprintf(buf, "action_web_request() request '%.*s' took",http_msg->uri.len, http_msg->uri.p);
+    sprintf(buf, "action_web_request() request '%.*s' took",(int)http_msg->uri.len, http_msg->uri.p);
 
     DEBUG_TIMER_STOP(tid, NET_LOG, buf);
   }


### PR DESCRIPTION
Fixed compiler warning about type mismatch on sprintf field precision specifier argument (expected int, but http_msg->uri.len is size_t).