### PR TITLE
Use MAC address of first connected interface

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -235,6 +235,11 @@ bool mac(char *buf, int len, bool useDelimiter)
           continue;
         }
 
+        if ((ioctl(fd, SIOCGIFFLAGS, &s) < 0) || !(s.ifr_flags & IFF_RUNNING))
+        {
+          continue;
+        } 
+
         int i;
         int step=2;
         if (useDelimiter) {step=3;}


### PR DESCRIPTION
When getting MAC address, the current code just grabs the first valid MAC address for an interface, which if using wireless only means it will grab 'eth0' before 'wlan0' which may not be valid.

This uses the `IFF_RUNNING` flag to check if the interface is UP and CABLE CONNECTED for a better chance at getting the correct interface.

Supports 3399664ee59a38a53b46e690ac9159c4bcbe2f9e and closes #361