### PR TITLE
Make `serial_logger` easier to work with

### DIFF
--- a/source/serial_logger.c
+++ b/source/serial_logger.c
@@ -100,8 +100,7 @@ void broadcast_log(char *msg){
 void intHandler(int dummy) {
   _keepRunning = false;
   LOG(SLOG_LOG, LOG_NOTICE, "Stopping!\n");
-  if (_playback_file)  // If we are reading file, loop is irevelent
-    exit(0);
+  exit(0);
 }
 #else
 int serial_logger (int rs_fd, char *port_name, int logLevel, int slogger_packets, char *slogger_ids) 

--- a/source/serial_logger.c
+++ b/source/serial_logger.c
@@ -514,11 +514,6 @@ int main(int argc, char *argv[]) {
 
   printf("AqualinkD %s\n",VERSION);
 
-  if (getuid() != 0) {
-    fprintf(stderr, "ERROR %s Can only be run as root\n", argv[0]);
-    return EXIT_FAILURE;
-  }
-
   if (argc < 2 || access( argv[1], F_OK ) == -1 ) {
     fprintf(stderr, "ERROR, first param must be valid serial port, ie:-\n\t%s /dev/ttyUSB0\n\n", argv[0]);
     //fprintf(stderr, "Optional parameters are -d (debug) & -p <number> (log # packets) & -i <ID> & -r (raw) ie:=\n\t%s /dev/ttyUSB0 -d -p 1000 -i 0x08\n\n", argv[0]);


### PR DESCRIPTION
Don't force `serial_logger` to run as root. That's very bad (TM). Also exit immediately upon SIGINT.
More details in the individual commit messages